### PR TITLE
Logout when all browser tabs are closed (active session)

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -12,5 +12,6 @@ class VerifyCsrfToken extends Middleware
      * @var array<int, string>
      */
 protected $except = [
+   '/logout-on-tab-close',
 ];
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -37,5 +37,37 @@
         </main>
     </div>
 
+    @auth
+    <script>
+        // Generate a unique key for this tab
+        const tabKey = 'tab_' + Date.now();
+        localStorage.setItem(tabKey, 'open');
+
+        // Remove this tab key on unload, then check if it's last tab
+        window.addEventListener('beforeunload', function () {
+            localStorage.removeItem(tabKey);
+            setTimeout(() => {
+                const remaining = Object.keys(localStorage).filter(k => k.startsWith('tab_'));
+                if (remaining.length === 0) {
+                    navigator.sendBeacon('/logout-on-tab-close');
+                }
+            }, 0); // delay to ensure localStorage updates
+        });
+
+        // Optional cleanup for old/stale keys
+        window.addEventListener('load', function () {
+            const now = Date.now();
+            Object.keys(localStorage).forEach(key => {
+                if (key.startsWith('tab_')) {
+                    const time = parseInt(key.split('_')[1]);
+                    if (now - time > 1000 * 60 * 60) {
+                        localStorage.removeItem(key);
+                    }
+                }
+            });
+        });
+    </script>
+    @endauth
+
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -79,4 +79,4 @@ Route::post('/logout-on-tab-close', function () {
     Session::invalidate();
     Session::regenerateToken();
     return response()->noContent(); // 204 No Content
-});
+})->middleware('auth'); 

--- a/routes/web.php
+++ b/routes/web.php
@@ -74,6 +74,7 @@ Route::get('/cake/order', [App\Http\Controllers\CakeController::class, 'order'])
 });   
 require __DIR__.'/auth.php';
 
+//logout user when all tabs are close
 Route::post('/logout-on-tab-close', function () {
     Auth::logout();
     Session::invalidate();

--- a/routes/web.php
+++ b/routes/web.php
@@ -74,3 +74,9 @@ Route::get('/cake/order', [App\Http\Controllers\CakeController::class, 'order'])
 });   
 require __DIR__.'/auth.php';
 
+Route::post('/logout-on-tab-close', function () {
+    Auth::logout();
+    Session::invalidate();
+    Session::regenerateToken();
+    return response()->noContent(); // 204 No Content
+});


### PR DESCRIPTION
 Feature: Logout user when all browser tabs are closed (session still active)

This PR implements a feature that logs out the user automatically when all browser tabs are closed, even if the Laravel session has not yet expired.

 Changes Included:
- Added exception for `/logout-on-tab-close` in `VerifyCsrfToken.php` to bypass CSRF protection.
- Implemented tab-count logic in `app.blade.php` using `localStorage` and `beforeunload` to track active tabs.
- Created new route `/logout-on-tab-close` in `web.php` to handle logout triggered from JS.
- Ensured session is destroyed from backend when triggered by the tab-close logic.

 Tested:
- Feature tested on multiple browsers (Chrome, Firefox)
- Verified logout only occurs after closing all tabs
- Session was retained if at least one tab remained open

 Files Changed:
- `app/Http/Middleware/VerifyCsrfToken.php`
- `resources/views/layouts/app.blade.php`
- `routes/web.php`

